### PR TITLE
Added HTTP-01 support for traefik

### DIFF
--- a/build/default.properties
+++ b/build/default.properties
@@ -6,4 +6,4 @@ K8S_NAME=traefik-ingress-controller
 K8S_APP=traefik-ingress-lb
 
 TRAEFIK_IMAGE=traefik
-TRAEFIK_VERSION=v1.4.0
+TRAEFIK_VERSION=v1.5.0-rc5

--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -26,6 +26,8 @@ data:
 
     [acme]
     acmeLogging = true
+      [acme.httpChallenge]
+      entryPoint = "http"
 
     email = "${ACEME_EMAIL}"
     storageFile = "/data/traefik/acme.json"


### PR DESCRIPTION
Need to support HTTP-01 stuff

TLN-SNI-01 is being disabled.
https://community.letsencrypt.org/t/2018-01-11-update-regarding-acme-tls-sni-and-shared-hosting-infrastructure/50188