### PR TITLE
Allow to set the ingress controller to create an internal load balancer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,11 @@ properties([
       defaultValue: 'hans.flaatten@evry.com',
       description: 'LetsEncrypt ACEME registration email',
     ),
+    string(
+      name: 'K8S_INTERNAL_LB',
+      defaultValue: 'false',
+      description: 'Use internal load balancer. IE not on the internet',
+    )
   ])
 ])
 
@@ -39,7 +44,8 @@ node('jenkins-docker-3') {
       config = new Config(this).branchProperties(envPatterns)
 
       [ 'K8S_CLUSTER',
-        'ACME_EMAIL'
+        'ACME_EMAIL',
+        'K8S_INTERNAL_LB'
       ].eachWithIndex { item, index -> config[item] = env[item] }
 
 

--- a/build/default.properties
+++ b/build/default.properties
@@ -4,6 +4,8 @@ K8S_CLUSTER=kubernetes.ace.dev
 K8S_NAMESPACE=kube-system
 K8S_NAME=traefik-ingress-controller
 K8S_APP=traefik-ingress-lb
+K8S_INTERNAL_LB=false
+
 
 TRAEFIK_IMAGE=traefik
 TRAEFIK_VERSION=v1.5.2

--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -7,9 +7,7 @@ metadata:
 data:
   traefik.toml: |-
     checkNewVersion = false
-
     logLevel = "WARN"
-
     InsecureSkipVerify = true
 
     defaultEntryPoints = ["http", "https"]
@@ -17,16 +15,12 @@ data:
     [entryPoints]
       [entryPoints.http]
       address = ":80"
-        [entryPoints.http.redirect]
-        entryPoint = "https"
+      [entryPoints.http.redirect]
+      entryPoint = "https"
 
       [entryPoints.https]
       address = ":443"
         [entryPoints.https.tls]
-          [[entryPoints.https.tls.certificates]]
-          CertFile = "/etc/tls/skjema-danica-no.crt"
-          KeyFile = "/etc/tls/skjema-danica-no.key"
-
 
     [acme]
     acmeLogging = true
@@ -41,9 +35,9 @@ data:
         entryPoint = "http"
     [web]
     address = ":8080"
-    
+
     [accessLog]
     format = "json"
-     
+
     [web.metrics.prometheus]
     Buckets=[0.1,0.3,1.2,5.0]

--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -7,7 +7,9 @@ metadata:
 data:
   traefik.toml: |-
     checkNewVersion = false
+
     logLevel = "WARN"
+
     InsecureSkipVerify = true
 
     defaultEntryPoints = ["http", "https"]
@@ -15,8 +17,8 @@ data:
     [entryPoints]
       [entryPoints.http]
       address = ":80"
-      [entryPoints.http.redirect]
-      entryPoint = "https"
+        [entryPoints.http.redirect]
+        entryPoint = "https"
 
       [entryPoints.https]
       address = ":443"

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -10,6 +10,7 @@ metadata:
     prometheus.io/path: "/metrics"
     prometheus.io/port: "8080"
     prometheus.io/scrape: "true"
+    service.beta.kubernetes.io/azure-load-balancer-internal: "${K8S_INTERNAL_LB}"
 spec:
   selector:
     k8s-app: traefik-ingress-lb


### PR DESCRIPTION
I am a bit unsure about this pull request.
It is very specific to azure, and we want to be a bit more agnostic to cloud provider.
Still, we do the same azure-specific stuff for the volumes.

The pull request allows us to create internal loadbalancers that gets the IP from the VNET instead of a public load-balancer with a public IP. This to be able to add more infrastructure in between the public interface and the internal infrastructure, like firewalls, fraud-detection etc.